### PR TITLE
Fixes to support shell function names

### DIFF
--- a/extras/ambari_functions.sh
+++ b/extras/ambari_functions.sh
@@ -41,7 +41,7 @@ ambari_configs() {
   #defaultfs=$(${config_get} core-site | awk -F'"' '$2 == "fs.defaultFS" {print $4}' | head -1)
 }
 
-ambari-change-pass() {
+ambari_change_pass() {
   # expects: ambari-change-pass username oldpass newpass
 read -r -d '' body <<EOF
 { "Users": { "user_name": "$1", "old_password": "$2", "password": "$3" }}
@@ -83,7 +83,7 @@ function ambari_wait() {
 # Only useful during a fresh install where we expect no failures
 # Will not work if any requested TIMEDOUT/ABORTED
 function ambari_wait_requests_completed() {
-      ambari-get-cluster
+      ambari_get_cluster
       # Poll for completion
       ambari_wait "${ambari_curl}/clusters/${ambari_cluster}/requests \
             | grep -Eo 'http://.*/requests/[^\"]+' \
@@ -96,7 +96,7 @@ function ambari_wait_requests_completed() {
 }
 
 function ambari_wait_request_complete() {
-      ambari-get-cluster
+      ambari_get_cluster
       # Poll for completion
       ambari_wait "${ambari_curl}/clusters/${ambari_cluster}/requests/${1} \
             | grep request_status \

--- a/extras/ambari_functions.sh
+++ b/extras/ambari_functions.sh
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env bash
 ## really bad hacked scripts that I've written dozens of times and
 ##   finally going to start consolidating ...
 

--- a/extras/ambari_functions.sh
+++ b/extras/ambari_functions.sh
@@ -24,14 +24,14 @@ export ambari_curl="${ambari_curl_cmd} ${ambari_api}"
 
 ## auto-detect cluster
 
-ambari-get-cluster() {
+ambari_get_cluster() {
   ambari_cluster=$(${ambari_curl}/clusters \
       | python -c 'import sys,json; \
             print json.load(sys.stdin)["items"][0]["Clusters"]["cluster_name"]')
 }
 
-ambari-configs() {
-  ambari-get-cluster
+ambari_configs() {
+  ambari_get_cluster
   ambari_configs_sh="/var/lib/ambari-server/resources/scripts/configs.sh \
     -u ${ambari_user} -p ${ambari_pass} \
     -port ${ambari_port} $(if [ ${ambari_protocol} == 'https' ]; then echo '-s '; fi)"


### PR DESCRIPTION
Some of the shell functions used dashes, which seem to be prohibited in some versions.   Changed these to underscores.   Many of the functions already used underscores, so this made the script more uniform as well.
