### PR TITLE
Set force_https_protocol=PROTOCOL_TLSv1_2 ambari-agent.ini

### DIFF
--- a/ambari-bootstrap.sh
+++ b/ambari-bootstrap.sh
@@ -188,6 +188,8 @@ case "${lsb_dist}" in
         printf "## fetch ambari repo\n"
         ${curl} -o /etc/yum.repos.d/ambari.repo \
             "${ambari_repo}"
+            
+        sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/ambari.repo 
 
         if [ "${install_ambari_agent}" = true ]; then
             printf "## installing ambari-agent\n"

--- a/ambari-bootstrap.sh
+++ b/ambari-bootstrap.sh
@@ -193,6 +193,7 @@ case "${lsb_dist}" in
             printf "## installing ambari-agent\n"
             yum install -q -y ambari-agent
             sed -i.orig -r 's/^[[:space:]]*hostname=.*/hostname='"${ambari_server}"'/' \
+                        -r 's/\[security\]/\[security\]\nforce_https_protocol=PROTOCOL_TLSv1_2/' \
                 /etc/ambari-agent/conf/ambari-agent.ini
             chkconfig ambari-agent on
             ambari-agent start

--- a/ambari-bootstrap.sh
+++ b/ambari-bootstrap.sh
@@ -192,8 +192,7 @@ case "${lsb_dist}" in
         if [ "${install_ambari_agent}" = true ]; then
             printf "## installing ambari-agent\n"
             yum install -q -y ambari-agent
-            sed -i.orig -r 's/^[[:space:]]*hostname=.*/hostname='"${ambari_server}"'/' \
-                        -r 's/\[security\]/\[security\]\nforce_https_protocol=PROTOCOL_TLSv1_2/' \
+             sed -i.orig -r 's/^[[:space:]]*hostname=.*/hostname='"${ambari_server}"'/;s/\[security\]/\[security\]\nforce_https_protocol=PROTOCOL_TLSv1_2/' \
                 /etc/ambari-agent/conf/ambari-agent.ini
             chkconfig ambari-agent on
             ambari-agent start


### PR DESCRIPTION
Ambari agents now seem to require force_https_protocol=PROTOCOL_TLSv1_2 for registering
https://community.hortonworks.com/articles/188269/javapython-updates-and-ambari-agent-tls-settings.html